### PR TITLE
Add set-playhead timecode command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ The CLI reads the config file above for the port and token.
 ```bash
 ./cli/premiere-bridge.js ping
 ./cli/premiere-bridge.js reload-project
+./cli/premiere-bridge.js sequence-info
+./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
+./cli/premiere-bridge.js set-playhead --timecode 00;00;10;00
 ./cli/premiere-bridge.js add-markers --file markers.json
 ./cli/premiere-bridge.js add-markers-file --file markers.json
+./cli/premiere-bridge.js toggle-video-track --track V1 --visible false
 ```
 
 Markers JSON example:
@@ -61,8 +65,12 @@ Color indices:
 
 - `ping`
 - `reload-project`
+- `sequence-info`
+- `debug-timecode`
+- `set-playhead`
 - `add-markers`
 - `add-markers-file`
+- `toggle-video-track`
 
 ## Security
 

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -13,6 +13,7 @@ Usage:
   premiere-bridge reload-project [--port N] [--token TOKEN]
   premiere-bridge sequence-info [--port N] [--token TOKEN]
   premiere-bridge debug-timecode --timecode 00;02;00;00 [--port N] [--token TOKEN]
+  premiere-bridge set-playhead --timecode 00;00;10;00 [--port N] [--token TOKEN]
   premiere-bridge add-markers --file markers.json [--port N] [--token TOKEN]
   premiere-bridge add-markers --markers '[{"timeSeconds":1.23,"name":"Note"}]' [--port N] [--token TOKEN]
   premiere-bridge add-markers-file --file /path/to/markers.json [--port N] [--token TOKEN]
@@ -192,6 +193,15 @@ async function main() {
       throw new Error("Provide --timecode for debug-timecode");
     }
     const result = await sendCommand(config, "debugTimecode", { timecode: args.timecode });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "set-playhead") {
+    if (!args.timecode) {
+      throw new Error("Provide --timecode for set-playhead");
+    }
+    const result = await sendCommand(config, "setPlayheadTimecode", { timecode: args.timecode });
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -158,6 +158,9 @@
     if (command === "debugTimecode") {
       return evalExtendScript("debugTimecode", payload || {});
     }
+    if (command === "setPlayheadTimecode") {
+      return evalExtendScript("setPlayheadTimecode", payload || {});
+    }
     if (command === "toggleVideoTrack") {
       return evalExtendScript("toggleVideoTrack", payload || {});
     }


### PR DESCRIPTION
## Summary\n- add set-playhead CLI command and panel routing\n- implement setPlayheadTimecode in ExtendScript with QE/DOM fallbacks\n- document new commands in README\n\n## Testing\n- ./cli/premiere-bridge.js set-playhead --timecode "00;00;10;00"\n\nCloses #11