### PR TITLE
Add set-in-out points command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js sequence-info
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
 ./cli/premiere-bridge.js set-playhead --timecode 00;00;10;00
+./cli/premiere-bridge.js set-in-out --in "00;00;10;00" --out "00;00;20;00"
 ./cli/premiere-bridge.js add-markers --file markers.json
 ./cli/premiere-bridge.js add-markers-file --file markers.json
 ./cli/premiere-bridge.js toggle-video-track --track V1 --visible false
@@ -68,6 +69,7 @@ Color indices:
 - `sequence-info`
 - `debug-timecode`
 - `set-playhead`
+- `set-in-out`
 - `add-markers`
 - `add-markers-file`
 - `toggle-video-track`

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -14,6 +14,7 @@ Usage:
   premiere-bridge sequence-info [--port N] [--token TOKEN]
   premiere-bridge debug-timecode --timecode 00;02;00;00 [--port N] [--token TOKEN]
   premiere-bridge set-playhead --timecode 00;00;10;00 [--port N] [--token TOKEN]
+  premiere-bridge set-in-out --in 00;00;10;00 --out 00;00;20;00 [--port N] [--token TOKEN]
   premiere-bridge add-markers --file markers.json [--port N] [--token TOKEN]
   premiere-bridge add-markers --markers '[{"timeSeconds":1.23,"name":"Note"}]' [--port N] [--token TOKEN]
   premiere-bridge add-markers-file --file /path/to/markers.json [--port N] [--token TOKEN]
@@ -202,6 +203,18 @@ async function main() {
       throw new Error("Provide --timecode for set-playhead");
     }
     const result = await sendCommand(config, "setPlayheadTimecode", { timecode: args.timecode });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "set-in-out") {
+    if (!args.in || !args.out) {
+      throw new Error("Provide --in and --out timecodes for set-in-out");
+    }
+    const result = await sendCommand(config, "setInOutPoints", {
+      inTimecode: args.in,
+      outTimecode: args.out
+    });
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -161,6 +161,9 @@
     if (command === "setPlayheadTimecode") {
       return evalExtendScript("setPlayheadTimecode", payload || {});
     }
+    if (command === "setInOutPoints") {
+      return evalExtendScript("setInOutPoints", payload || {});
+    }
     if (command === "toggleVideoTrack") {
       return evalExtendScript("toggleVideoTrack", payload || {});
     }


### PR DESCRIPTION
## Summary
- add `set-in-out` CLI command
- route `setInOutPoints` through the panel server
- implement `setInOutPoints` in ExtendScript with timecode/ticks/seconds support
- prefer DOM `setInPoint`/`setOutPoint` before QE to avoid unit mismatches

## Testing
- `./cli/premiere-bridge.js set-in-out --in "00;00;10;00" --out "00;00;20;00"`

Closes #13
