### PR TITLE
Add save-project command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The CLI reads the config file above for the port and token.
 ```bash
 ./cli/premiere-bridge.js ping
 ./cli/premiere-bridge.js reload-project
+./cli/premiere-bridge.js save-project
 ./cli/premiere-bridge.js sequence-info
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
 ./cli/premiere-bridge.js set-playhead --timecode 00;00;10;00
@@ -66,6 +67,7 @@ Color indices:
 
 - `ping`
 - `reload-project`
+- `save-project`
 - `sequence-info`
 - `debug-timecode`
 - `set-playhead`

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -11,6 +11,7 @@ function usage(exitCode) {
 Usage:
   premiere-bridge ping [--port N] [--token TOKEN]
   premiere-bridge reload-project [--port N] [--token TOKEN]
+  premiere-bridge save-project [--port N] [--token TOKEN]
   premiere-bridge sequence-info [--port N] [--token TOKEN]
   premiere-bridge debug-timecode --timecode 00;02;00;00 [--port N] [--token TOKEN]
   premiere-bridge set-playhead --timecode 00;00;10;00 [--port N] [--token TOKEN]
@@ -172,6 +173,12 @@ async function main() {
 
   if (command === "reload-project") {
     const result = await sendCommand(config, "reloadProject", {});
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "save-project") {
+    const result = await sendCommand(config, "saveProject", {});
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -152,6 +152,9 @@
     if (command === "reloadProject") {
       return evalExtendScript("reloadProject", {});
     }
+    if (command === "saveProject") {
+      return evalExtendScript("saveProject", payload || {});
+    }
     if (command === "getSequenceInfo") {
       return evalExtendScript("getSequenceInfo", {});
     }

--- a/premiere-bridge/jsx/premiere-bridge.jsx
+++ b/premiere-bridge/jsx/premiere-bridge.jsx
@@ -752,6 +752,25 @@ PremiereBridge.addMarkersFromJSON = function (jsonStr) {
   }
 };
 
+PremiereBridge.saveProject = function (jsonStr) {
+  try {
+    var project = app.project;
+    if (!project) {
+      return PremiereBridge._err("No project loaded");
+    }
+
+    try {
+      project.save();
+    } catch (saveErr) {
+      return PremiereBridge._err("Failed to save project", { error: String(saveErr) });
+    }
+
+    return PremiereBridge._ok({ method: "project.save", path: project.path || null });
+  } catch (err) {
+    return PremiereBridge._err(String(err));
+  }
+};
+
 PremiereBridge.reloadProject = function () {
   try {
     var project = app.project;


### PR DESCRIPTION
## Summary
- add `save-project` CLI command
- route `saveProject` through the panel server
- implement `PremiereBridge.saveProject` with `app.project.save()`
- document the command in `README.md`

## Testing
- `./cli/premiere-bridge.js save-project` (requires restarting/reloading the CEP panel to pick up the new command)

Closes #53
