### PR TITLE
Add razor-cut command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
 ./cli/premiere-bridge.js set-playhead --timecode 00;00;10;00
 ./cli/premiere-bridge.js set-in-out --in "00;00;10;00" --out "00;00;20;00"
+./cli/premiere-bridge.js razor-cut --timecode "00;00;10;00"
 ./cli/premiere-bridge.js add-markers --file markers.json
 ./cli/premiere-bridge.js add-markers-file --file markers.json
 ./cli/premiere-bridge.js toggle-video-track --track V1 --visible false
@@ -78,6 +79,7 @@ Color indices:
 - `debug-timecode`
 - `set-playhead`
 - `set-in-out`
+- `razor-cut`
 - `add-markers`
 - `add-markers-file`
 - `toggle-video-track`

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -19,6 +19,7 @@ Usage:
   premiere-bridge debug-timecode --timecode 00;02;00;00 [--port N] [--token TOKEN]
   premiere-bridge set-playhead --timecode 00;00;10;00 [--port N] [--token TOKEN]
   premiere-bridge set-in-out --in 00;00;10;00 --out 00;00;20;00 [--port N] [--token TOKEN]
+  premiere-bridge razor-cut (--timecode 00;00;10;00 | --seconds 10 | --ticks 254016000000) [--unit ticks|seconds|timecode|playhead] [--port N] [--token TOKEN]
   premiere-bridge add-markers --file markers.json [--port N] [--token TOKEN]
   premiere-bridge add-markers --markers '[{"timeSeconds":1.23,"name":"Note"}]' [--port N] [--token TOKEN]
   premiere-bridge add-markers-file --file /path/to/markers.json [--port N] [--token TOKEN]
@@ -257,6 +258,28 @@ async function main() {
       inTimecode: args.in,
       outTimecode: args.out
     });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "razor-cut") {
+    if (args.timecode === undefined && args.seconds === undefined && args.ticks === undefined) {
+      throw new Error("Provide --timecode, --seconds, or --ticks for razor-cut");
+    }
+    const payload = {};
+    if (args.timecode !== undefined) {
+      payload.timecode = String(args.timecode);
+    }
+    if (args.seconds !== undefined) {
+      payload.seconds = Number(args.seconds);
+    }
+    if (args.ticks !== undefined) {
+      payload.ticks = Number(args.ticks);
+    }
+    if (args.unit !== undefined) {
+      payload.unit = String(args.unit);
+    }
+    const result = await sendCommand(config, "razorAtTimecode", payload);
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -176,6 +176,9 @@
     if (command === "setInOutPoints") {
       return evalExtendScript("setInOutPoints", payload || {});
     }
+    if (command === "razorAtTimecode") {
+      return evalExtendScript("razorAtTimecode", payload || {});
+    }
     if (command === "toggleVideoTrack") {
       return evalExtendScript("toggleVideoTrack", payload || {});
     }


### PR DESCRIPTION
Implements a new `razor-cut` command end-to-end (CLI -> panel -> ExtendScript).\n\nKey points:\n- Adds `razor-cut` to the CLI with `--timecode|--seconds|--ticks` and `--unit`.\n- Routes `razorAtTimecode` through the panel server.\n- Uses QE razor/addEdit across all tracks and reports DOM-based diagnostics.\n\nTesting:\n- `./cli/premiere-bridge.js razor-cut --timecode "00;29;33;03" --unit timecode` on a duplicated sequence.\n- Verified cut detection via DOM clip counts.\n\nCloses #17.