### PR TITLE
Add sequence-inventory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js list-sequences
 ./cli/premiere-bridge.js open-sequence --name "Rough Cut"
 ./cli/premiere-bridge.js sequence-info
+./cli/premiere-bridge.js sequence-inventory
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
 ./cli/premiere-bridge.js set-playhead --timecode 00;00;10;00
 ./cli/premiere-bridge.js set-in-out --in "00;00;10;00" --out "00;00;20;00"
@@ -76,6 +77,7 @@ Color indices:
 - `list-sequences`
 - `open-sequence`
 - `sequence-info`
+- `sequence-inventory`
 - `debug-timecode`
 - `set-playhead`
 - `set-in-out`

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -16,6 +16,7 @@ Usage:
   premiere-bridge list-sequences [--port N] [--token TOKEN]
   premiere-bridge open-sequence (--name NAME | --id ID) [--port N] [--token TOKEN]
   premiere-bridge sequence-info [--port N] [--token TOKEN]
+  premiere-bridge sequence-inventory [--port N] [--token TOKEN]
   premiere-bridge debug-timecode --timecode 00;02;00;00 [--port N] [--token TOKEN]
   premiere-bridge set-playhead --timecode 00;00;10;00 [--port N] [--token TOKEN]
   premiere-bridge set-in-out --in 00;00;10;00 --out 00;00;20;00 [--port N] [--token TOKEN]
@@ -228,6 +229,12 @@ async function main() {
 
   if (command === "sequence-info") {
     const result = await sendCommand(config, "getSequenceInfo", {});
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "sequence-inventory") {
+    const result = await sendCommand(config, "sequenceInventory", {});
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -167,6 +167,9 @@
     if (command === "getSequenceInfo") {
       return evalExtendScript("getSequenceInfo", {});
     }
+    if (command === "sequenceInventory") {
+      return evalExtendScript("sequenceInventory", {});
+    }
     if (command === "debugTimecode") {
       return evalExtendScript("debugTimecode", payload || {});
     }


### PR DESCRIPTION
Implements #58 by adding a machine-friendly sequence inventory command.\n\nWhat it does:\n- Adds `sequence-inventory` to the CLI.\n- Routes `sequenceInventory` through the panel server.\n- Returns sequence timing/settings and per-track clip timing (start/end/duration + source in/out when available).\n\nTesting:\n- `./cli/premiere-bridge.js sequence-inventory` after panel reload.\n\nCloses #58.