### PR TITLE
Add extract-range and ripple-delete-selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
 ./cli/premiere-bridge.js set-playhead --timecode 00;00;10;00
 ./cli/premiere-bridge.js set-in-out --in "00;00;10;00" --out "00;00;20;00"
+./cli/premiere-bridge.js extract-range --in "00;00;10;00" --out "00;00;20;00"
+./cli/premiere-bridge.js ripple-delete-selection
 ./cli/premiere-bridge.js razor-cut --timecode "00;00;10;00"
 ./cli/premiere-bridge.js add-markers --file markers.json
 ./cli/premiere-bridge.js add-markers-file --file markers.json
@@ -81,6 +83,8 @@ Color indices:
 - `debug-timecode`
 - `set-playhead`
 - `set-in-out`
+- `extract-range`
+- `ripple-delete-selection`
 - `razor-cut`
 - `add-markers`
 - `add-markers-file`

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -20,6 +20,8 @@ Usage:
   premiere-bridge debug-timecode --timecode 00;02;00;00 [--port N] [--token TOKEN]
   premiere-bridge set-playhead --timecode 00;00;10;00 [--port N] [--token TOKEN]
   premiere-bridge set-in-out --in 00;00;10;00 --out 00;00;20;00 [--port N] [--token TOKEN]
+  premiere-bridge extract-range (--in 00;00;10;00 | --in-ticks N | --in-seconds S) (--out 00;00;20;00 | --out-ticks N | --out-seconds S) [--command-id N] [--port N] [--token TOKEN]
+  premiere-bridge ripple-delete-selection [--command-id N] [--port N] [--token TOKEN]
   premiere-bridge razor-cut (--timecode 00;00;10;00 | --seconds 10 | --ticks 254016000000) [--unit ticks|seconds|timecode|playhead] [--port N] [--token TOKEN]
   premiere-bridge add-markers --file markers.json [--port N] [--token TOKEN]
   premiere-bridge add-markers --markers '[{"timeSeconds":1.23,"name":"Note"}]' [--port N] [--token TOKEN]
@@ -265,6 +267,57 @@ async function main() {
       inTimecode: args.in,
       outTimecode: args.out
     });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "extract-range") {
+    const payload = {};
+    if (args.in !== undefined) {
+      payload.inTimecode = String(args.in);
+    }
+    if (args["in-ticks"] !== undefined) {
+      payload.inTicks = Number(args["in-ticks"]);
+    }
+    if (args["in-seconds"] !== undefined) {
+      payload.inSeconds = Number(args["in-seconds"]);
+    }
+    if (args.out !== undefined) {
+      payload.outTimecode = String(args.out);
+    }
+    if (args["out-ticks"] !== undefined) {
+      payload.outTicks = Number(args["out-ticks"]);
+    }
+    if (args["out-seconds"] !== undefined) {
+      payload.outSeconds = Number(args["out-seconds"]);
+    }
+    if (args["command-id"] !== undefined) {
+      payload.commandId = Number(args["command-id"]);
+    }
+
+    const hasIn =
+      payload.inTimecode !== undefined ||
+      payload.inTicks !== undefined ||
+      payload.inSeconds !== undefined;
+    const hasOut =
+      payload.outTimecode !== undefined ||
+      payload.outTicks !== undefined ||
+      payload.outSeconds !== undefined;
+    if (!hasIn || !hasOut) {
+      throw new Error("Provide in/out via --in/--out, --in-ticks/--out-ticks, or --in-seconds/--out-seconds");
+    }
+
+    const result = await sendCommand(config, "extractRange", payload);
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "ripple-delete-selection") {
+    const payload = {};
+    if (args["command-id"] !== undefined) {
+      payload.commandId = Number(args["command-id"]);
+    }
+    const result = await sendCommand(config, "rippleDeleteSelection", payload);
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -179,6 +179,12 @@
     if (command === "setInOutPoints") {
       return evalExtendScript("setInOutPoints", payload || {});
     }
+    if (command === "extractRange") {
+      return evalExtendScript("extractRange", payload || {});
+    }
+    if (command === "rippleDeleteSelection") {
+      return evalExtendScript("rippleDeleteSelection", payload || {});
+    }
     if (command === "razorAtTimecode") {
       return evalExtendScript("razorAtTimecode", payload || {});
     }


### PR DESCRIPTION
Implements the core rough-cut deletion primitives by addressing both #18 and #59 together.\n\nWhat’s included:\n- `extract-range` command: set in/out, razor boundaries, then extract/ripple delete the range.\n- `ripple-delete-selection` command: compute selection bounds, then delegate to `extract-range`.\n- Shared ExtendScript helpers for in/out parsing, setting, selection bounds, and extract fallbacks.\n\nTesting:\n- `./cli/premiere-bridge.js extract-range --in "00;00;16;00" --out "00;00;18;00"` on a duplicated sequence (timeline length decreased by ~2s).\n- `./cli/premiere-bridge.js ripple-delete-selection` on a selected clip range in a duplicated sequence.\n\nCloses #18. Closes #59.