### PR TITLE
Document rough cut command set

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ Color indices:
 - `add-markers-file`
 - `toggle-video-track`
 
+## Rough Cut Command Set
+
+These primitives are sufficient for a safe, transcript-driven rough cut:
+
+- `duplicate-sequence` (non-destructive editing)
+- `open-sequence` / `list-sequences` (reliable context switching)
+- `sequence-inventory` (map transcript time to sequence time)
+- `razor-cut` (cut boundaries across all tracks)
+- `extract-range` (remove a time span and ripple closed)
+- `ripple-delete-selection` (selection-driven variant)
+
+Suggested workflow for transcript ranges to keep:
+
+1) Duplicate and activate the working sequence.
+2) Use `sequence-inventory` to translate transcript timecodes into sequence time.
+3) Compute the gaps between "kept" ranges.
+4) Run `extract-range` on each gap from end to start.
+
 ## Security
 
 The panel only listens on `127.0.0.1` and requires the shared token stored in the config file.


### PR DESCRIPTION
Closes #60 by documenting the now-complete rough cut command set and the recommended safe workflow.\n\nChanges:\n- Adds a "Rough Cut Command Set" section to `README.md`.\n- Marks all prerequisite primitives as completed on the issue.\n\nThis sets up #61 (orchestration) with a clear contract and ordering.