### PR TITLE
Add rough-cut orchestration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js set-in-out --in "00;00;10;00" --out "00;00;20;00"
 ./cli/premiere-bridge.js extract-range --in "00;00;10;00" --out "00;00;20;00"
 ./cli/premiere-bridge.js ripple-delete-selection
+./cli/premiere-bridge.js rough-cut --ranges-file ./ranges.json --name "Transcript Rough Cut"
 ./cli/premiere-bridge.js razor-cut --timecode "00;00;10;00"
 ./cli/premiere-bridge.js add-markers --file markers.json
 ./cli/premiere-bridge.js add-markers-file --file markers.json
@@ -85,6 +86,7 @@ Color indices:
 - `set-in-out`
 - `extract-range`
 - `ripple-delete-selection`
+- `rough-cut`
 - `razor-cut`
 - `add-markers`
 - `add-markers-file`
@@ -107,6 +109,35 @@ Suggested workflow for transcript ranges to keep:
 2) Use `sequence-inventory` to translate transcript timecodes into sequence time.
 3) Compute the gaps between "kept" ranges.
 4) Run `extract-range` on each gap from end to start.
+
+## Rough Cut Orchestration
+
+`rough-cut` automates the workflow above using inclusion ranges.
+
+Ranges JSON can be an array or an object with `ranges`/`segments`:
+
+```json
+{
+  "ranges": [
+    { "start": "00;00;02;00", "end": "00;00;06;00" },
+    { "start": "00;00;10;00", "end": "00;00;16;00" }
+  ]
+}
+```
+
+Example:
+
+```bash
+./cli/premiere-bridge.js rough-cut \
+  --ranges-file /Users/brents/code/codex-premiere/ranges.json \
+  --name "Rough Cut - Transcript" \
+  --padding-seconds 0.25
+```
+
+Notes:
+- The command duplicates the active sequence before editing.
+- By default, transcript times are offset by the sequence start time. Use `--no-offset` if your ranges are already in sequence time.
+- Gaps are processed from end to start to keep earlier times stable.
 
 ## Security
 

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -5,6 +5,7 @@ const os = require("os");
 const http = require("http");
 
 const DEFAULT_PORT = 17321;
+const TICKS_PER_SECOND = 254016000000;
 
 function usage(exitCode) {
   const text = `
@@ -22,6 +23,7 @@ Usage:
   premiere-bridge set-in-out --in 00;00;10;00 --out 00;00;20;00 [--port N] [--token TOKEN]
   premiere-bridge extract-range (--in 00;00;10;00 | --in-ticks N | --in-seconds S) (--out 00;00;20;00 | --out-ticks N | --out-seconds S) [--command-id N] [--port N] [--token TOKEN]
   premiere-bridge ripple-delete-selection [--command-id N] [--port N] [--token TOKEN]
+  premiere-bridge rough-cut (--ranges-file /path/to/ranges.json | --ranges '[{"start":"00;00;10;00","end":"00;00;20;00"}]') [--name NAME] [--padding-seconds S] [--padding-frames N] [--no-offset] [--port N] [--token TOKEN]
   premiere-bridge razor-cut (--timecode 00;00;10;00 | --seconds 10 | --ticks 254016000000) [--unit ticks|seconds|timecode|playhead] [--port N] [--token TOKEN]
   premiere-bridge add-markers --file markers.json [--port N] [--token TOKEN]
   premiere-bridge add-markers --markers '[{"timeSeconds":1.23,"name":"Note"}]' [--port N] [--token TOKEN]
@@ -101,6 +103,22 @@ function normalizeMarkers(input) {
   return null;
 }
 
+function normalizeRanges(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (input && Array.isArray(input.ranges)) {
+    return input.ranges;
+  }
+  if (input && Array.isArray(input.segments)) {
+    return input.segments;
+  }
+  if (input && Array.isArray(input.items)) {
+    return input.items;
+  }
+  return null;
+}
+
 function readMarkers(options) {
   if (options.file) {
     const raw = fs.readFileSync(options.file, "utf8");
@@ -122,6 +140,255 @@ function readMarkers(options) {
   }
 
   throw new Error("Provide --file or --markers");
+}
+
+function readRanges(options) {
+  if (options["ranges-file"]) {
+    const raw = fs.readFileSync(options["ranges-file"], "utf8");
+    const parsed = JSON.parse(raw);
+    const ranges = normalizeRanges(parsed);
+    if (!ranges) {
+      throw new Error("Ranges file must be an array or an object with a ranges/segments/items array");
+    }
+    return ranges;
+  }
+
+  if (options.ranges) {
+    const parsed = JSON.parse(options.ranges);
+    const ranges = normalizeRanges(parsed);
+    if (!ranges) {
+      throw new Error("--ranges must be a JSON array or an object with a ranges/segments/items array");
+    }
+    return ranges;
+  }
+
+  throw new Error("Provide --ranges-file or --ranges");
+}
+
+function getSequenceBounds(inventory) {
+  const seq = inventory && inventory.sequence ? inventory.sequence : {};
+  const startTicks = Number(seq.start && seq.start.ticks ? seq.start.ticks : 0) || 0;
+  const tracks = inventory && inventory.tracks ? inventory.tracks : {};
+  const allTracks = [...(tracks.video || []), ...(tracks.audio || [])];
+  let endTicks = startTicks;
+  for (const track of allTracks) {
+    for (const clip of track.clips || []) {
+      const end = Number(clip.end && clip.end.ticks);
+      if (!Number.isNaN(end) && end > endTicks) {
+        endTicks = end;
+      }
+    }
+  }
+  return { startTicks, endTicks };
+}
+
+function deriveTimebase(inventory) {
+  const seq = inventory && inventory.sequence ? inventory.sequence : {};
+  const timebase = Number(seq.timebase);
+  if (!Number.isNaN(timebase) && timebase > 0) {
+    return timebase;
+  }
+  throw new Error("Sequence timebase is missing or invalid");
+}
+
+function deriveNominalFps(inventory, timebase) {
+  const seq = inventory && inventory.sequence ? inventory.sequence : {};
+  const fps = Number(seq.nominalFps);
+  if (!Number.isNaN(fps) && fps > 0) {
+    return fps;
+  }
+  const derived = Math.round(TICKS_PER_SECOND / Number(timebase));
+  if (!Number.isNaN(derived) && derived > 0) {
+    return derived;
+  }
+  return 30;
+}
+
+function parseTimecodeToFrames(timecode, fps, dropFrameHint) {
+  if (!timecode) {
+    return null;
+  }
+  const raw = String(timecode);
+  const dropFrame = raw.includes(";") || dropFrameHint === true;
+  const clean = raw.replace(/;/g, ":");
+  const parts = clean.split(":");
+  if (parts.length < 4) {
+    return null;
+  }
+  const [hh, mm, ss, ff] = parts.map((p) => Number(p));
+  if ([hh, mm, ss, ff].some((n) => Number.isNaN(n))) {
+    return null;
+  }
+  const totalMinutes = hh * 60 + mm;
+  let totalFrames = ((hh * 3600 + mm * 60 + ss) * fps) + ff;
+  if (dropFrame) {
+    const dropFrames = Math.round(fps * 0.066666);
+    totalFrames -= dropFrames * (totalMinutes - Math.floor(totalMinutes / 10));
+  }
+  return totalFrames;
+}
+
+function timecodeToTicks(timecode, context) {
+  const frames = parseTimecodeToFrames(timecode, context.fps, context.dropFrame);
+  if (frames === null) {
+    return null;
+  }
+  return Math.round(frames * context.timebase);
+}
+
+function secondsToTicks(seconds) {
+  const value = Number(seconds);
+  if (Number.isNaN(value)) {
+    return null;
+  }
+  return Math.round(value * TICKS_PER_SECOND);
+}
+
+function ticksToSeconds(ticks) {
+  return Number(ticks) / TICKS_PER_SECOND;
+}
+
+function paddingToTicks(args, context) {
+  let paddingTicks = 0;
+  if (args["padding-seconds"] !== undefined) {
+    const ticks = secondsToTicks(args["padding-seconds"]);
+    if (ticks !== null) {
+      paddingTicks += ticks;
+    }
+  }
+  if (args["padding-frames"] !== undefined) {
+    const frames = Number(args["padding-frames"]);
+    if (!Number.isNaN(frames)) {
+      paddingTicks += Math.round(frames * context.timebase);
+    }
+  }
+  if (args["padding-timecode"] !== undefined) {
+    const ticks = timecodeToTicks(String(args["padding-timecode"]), context);
+    if (ticks !== null) {
+      paddingTicks += ticks;
+    }
+  }
+  return Math.max(0, Math.round(paddingTicks));
+}
+
+function rangeField(value, context) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value === "number") {
+    return secondsToTicks(value);
+  }
+  const str = String(value);
+  if (str.includes(":") || str.includes(";")) {
+    return timecodeToTicks(str, context);
+  }
+  const numeric = Number(value);
+  if (!Number.isNaN(numeric)) {
+    return secondsToTicks(numeric);
+  }
+  return null;
+}
+
+function numericOrNull(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isNaN(n) ? null : n;
+}
+
+function rangeToTicks(range, context) {
+  const startTicksRaw =
+    numericOrNull(range.startTicks) ??
+    numericOrNull(range.inTicks) ??
+    (range.startSeconds !== undefined ? secondsToTicks(range.startSeconds) : null) ??
+    (range.inSeconds !== undefined ? secondsToTicks(range.inSeconds) : null) ??
+    (range.startTimecode !== undefined ? timecodeToTicks(range.startTimecode, context) : null) ??
+    (range.inTimecode !== undefined ? timecodeToTicks(range.inTimecode, context) : null) ??
+    rangeField(range.start, context) ??
+    rangeField(range.in, context);
+
+  const endTicksRaw =
+    numericOrNull(range.endTicks) ??
+    numericOrNull(range.outTicks) ??
+    (range.endSeconds !== undefined ? secondsToTicks(range.endSeconds) : null) ??
+    (range.outSeconds !== undefined ? secondsToTicks(range.outSeconds) : null) ??
+    (range.endTimecode !== undefined ? timecodeToTicks(range.endTimecode, context) : null) ??
+    (range.outTimecode !== undefined ? timecodeToTicks(range.outTimecode, context) : null) ??
+    rangeField(range.end, context) ??
+    rangeField(range.out, context);
+
+  if (startTicksRaw === null || endTicksRaw === null) {
+    return null;
+  }
+
+  let startTicks = Math.round(Number(startTicksRaw));
+  let endTicks = Math.round(Number(endTicksRaw));
+  if (Number.isNaN(startTicks) || Number.isNaN(endTicks)) {
+    return null;
+  }
+
+  if (!context.noOffset) {
+    startTicks += context.sequenceStartTicks;
+    endTicks += context.sequenceStartTicks;
+  }
+
+  return { startTicks, endTicks };
+}
+
+function clampRange(range, bounds) {
+  const start = Math.max(bounds.startTicks, range.startTicks);
+  const end = Math.min(bounds.endTicks, range.endTicks);
+  if (end <= start) {
+    return null;
+  }
+  return { startTicks: start, endTicks: end };
+}
+
+function normalizeIncludedRanges(ranges, context, bounds, paddingTicks) {
+  const normalized = [];
+  for (const [index, range] of ranges.entries()) {
+    const converted = rangeToTicks(range || {}, context);
+    if (!converted) {
+      throw new Error(`Range at index ${index} is missing valid start/end values`);
+    }
+    let startTicks = converted.startTicks - paddingTicks;
+    let endTicks = converted.endTicks + paddingTicks;
+    if (endTicks < startTicks) {
+      [startTicks, endTicks] = [endTicks, startTicks];
+    }
+    const clamped = clampRange({ startTicks, endTicks }, bounds);
+    if (clamped) {
+      normalized.push(clamped);
+    }
+  }
+
+  normalized.sort((a, b) => a.startTicks - b.startTicks);
+  const merged = [];
+  for (const range of normalized) {
+    const last = merged[merged.length - 1];
+    if (!last || range.startTicks > last.endTicks) {
+      merged.push({ ...range });
+      continue;
+    }
+    last.endTicks = Math.max(last.endTicks, range.endTicks);
+  }
+  return merged;
+}
+
+function computeGaps(included, bounds) {
+  const gaps = [];
+  let cursor = bounds.startTicks;
+  for (const range of included) {
+    if (range.startTicks > cursor) {
+      gaps.push({ startTicks: cursor, endTicks: range.startTicks });
+    }
+    cursor = Math.max(cursor, range.endTicks);
+  }
+  if (cursor < bounds.endTicks) {
+    gaps.push({ startTicks: cursor, endTicks: bounds.endTicks });
+  }
+  return gaps.filter((gap) => gap.endTicks > gap.startTicks);
 }
 
 function sendCommand(config, cmd, payload) {
@@ -319,6 +586,87 @@ async function main() {
     }
     const result = await sendCommand(config, "rippleDeleteSelection", payload);
     console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "rough-cut") {
+    const ranges = readRanges(args);
+    if (!ranges.length) {
+      throw new Error("No ranges provided");
+    }
+
+    const activeInfo = await sendCommand(config, "getSequenceInfo", {});
+    if (!activeInfo.body || !activeInfo.body.ok) {
+      throw new Error(`Failed to read active sequence: ${activeInfo.body && activeInfo.body.error}`);
+    }
+    const activeName = String(activeInfo.body.data && activeInfo.body.data.name ? activeInfo.body.data.name : "Sequence");
+    const duplicateName = args.name ? String(args.name) : `${activeName} Rough Cut`;
+
+    const dupResult = await sendCommand(config, "duplicateSequence", { name: duplicateName });
+    if (!dupResult.body || !dupResult.body.ok) {
+      throw new Error(`Failed to duplicate sequence: ${dupResult.body && dupResult.body.error}`);
+    }
+
+    const inventoryResult = await sendCommand(config, "sequenceInventory", {});
+    if (!inventoryResult.body || !inventoryResult.body.ok) {
+      throw new Error(`Failed to read sequence inventory: ${inventoryResult.body && inventoryResult.body.error}`);
+    }
+
+    const inventory = inventoryResult.body.data;
+    const bounds = getSequenceBounds(inventory);
+    const timebase = deriveTimebase(inventory);
+    const context = {
+      timebase,
+      fps: deriveNominalFps(inventory, timebase),
+      dropFrame: inventory.sequence && inventory.sequence.dropFrame === true,
+      sequenceStartTicks: bounds.startTicks,
+      noOffset: String(args["no-offset"]).toLowerCase() === "true"
+    };
+    const paddingTicks = paddingToTicks(args, context);
+    const included = normalizeIncludedRanges(ranges, context, bounds, paddingTicks);
+    if (!included.length) {
+      throw new Error("No valid ranges remain after normalization/clamping");
+    }
+
+    const gaps = computeGaps(included, bounds);
+    const processed = [];
+    for (const gap of gaps.slice().sort((a, b) => b.startTicks - a.startTicks)) {
+      const extractResult = await sendCommand(config, "extractRange", {
+        inTicks: gap.startTicks,
+        outTicks: gap.endTicks
+      });
+      if (!extractResult.body || !extractResult.body.ok) {
+        throw new Error(`Failed to extract gap ${gap.startTicks}-${gap.endTicks}: ${extractResult.body && extractResult.body.error}`);
+      }
+      processed.push({
+        gap,
+        seconds: ticksToSeconds(gap.endTicks - gap.startTicks),
+        method: extractResult.body.data && extractResult.body.data.extract && extractResult.body.data.extract.method
+      });
+    }
+
+    const saveResult = await sendCommand(config, "saveProject", {});
+
+    const output = {
+      duplicate: dupResult.body.data,
+      bounds: {
+        startTicks: String(bounds.startTicks),
+        endTicks: String(bounds.endTicks),
+        durationSeconds: ticksToSeconds(bounds.endTicks - bounds.startTicks)
+      },
+      padding: {
+        ticks: String(paddingTicks),
+        seconds: ticksToSeconds(paddingTicks)
+      },
+      includedRanges: included.map((r) => ({
+        startTicks: String(r.startTicks),
+        endTicks: String(r.endTicks),
+        durationSeconds: ticksToSeconds(r.endTicks - r.startTicks)
+      })),
+      gapsProcessed: processed,
+      saveProject: saveResult.body
+    };
+    console.log(JSON.stringify({ statusCode: 200, body: { ok: true, data: output } }, null, 2));
     return;
   }
 


### PR DESCRIPTION
Closes #61 by adding a CLI orchestration command that builds a rough cut from inclusion ranges.

What it does:
- Duplicates + activates the working sequence for non-destructive edits.
- Normalizes and merges inclusion ranges with optional padding.
- Offsets transcript timecodes by the sequence start time (opt out with `--no-offset`).
- Computes complement gaps and extracts them from end -> start.
- Saves the project at the end.

Testing:
- Ran `./cli/premiere-bridge.js rough-cut --ranges-file /tmp/roughcut-ranges.json --name "Rough Cut Orchestrator Test"`.
- Verified resulting duration is ~8.008 seconds via `sequence-inventory`.
