### PR TITLE
Populate panel Logs during bridge commands

### DIFF
--- a/premiere-bridge/css/panel.css
+++ b/premiere-bridge/css/panel.css
@@ -138,6 +138,7 @@ pre {
   border-radius: 6px;
   height: 140px;
   overflow: auto;
+  white-space: pre;
   font-size: 11px;
   color: #c7d0d9;
 }


### PR DESCRIPTION
## What
Fix the panel Logs section so it populates during bridge commands.

## Changes
- log incoming commands and summarized results in `panel.js`
- cap log history to avoid unbounded growth
- ensure long lines keep horizontal scrolling via `white-space: pre`
- log unauthorized requests and request errors for visibility

## Testing
- reload the panel in Premiere
- run `./cli/premiere-bridge.js ping`
- run `./cli/premiere-bridge.js sequence-info`
- verify Logs now shows command-in / command-out entries with scrollbars

Closes #71.
