### PR TITLE
Normalize rough-cut ranges to frame boundaries

### DIFF
--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -259,6 +259,9 @@
     if (command === "openSequence") {
       return evalExtendScript("openSequence", cleanPayload);
     }
+    if (command === "findMenuCommandId") {
+      return evalExtendScript("findMenuCommandId", cleanPayload);
+    }
     if (command === "getSequenceInfo") {
       return evalExtendScript("getSequenceInfo", {});
     }


### PR DESCRIPTION
## What
Reduce off-by-one gaps at rough-cut boundaries by normalizing range math to frame boundaries and using frame-aware seconds conversion.

## Changes
- convert seconds inputs to frame ticks using `fps` + `timebase`
- floor start endpoints and ceil end endpoints for seconds-based ranges
- normalize included ranges to frame boundaries before computing gaps
- include `extractInTicks`/`extractOutTicks` in rough-cut output for easier debugging
- add a small diagnostic command path for `findMenuCommandId` (may be unavailable in this CEP context)

## Testing
- ran syntax checks:
  - `node -c cli/premiere-bridge.js`
  - `node -c premiere-bridge/js/panel.js`
- timecode control test (no video gaps):
  - `./cli/premiere-bridge.js open-sequence --name "AE - Aligned Tracks"`
  - `./cli/premiere-bridge.js rough-cut --ranges '[{"start":"00;00;05;00","end":"00;00;07;00"},{"start":"00;00;10;00","end":"00;00;12;00"},{"start":"00;00;14;00","end":"00;00;16;00"},{"start":"00;00;20;00","end":"00;00;22;00"},{"start":"00;00;25;00","end":"00;00;27;00"},{"start":"00;00;30;00","end":"00;00;32;00"}]' --name "DEBUG Timecode MultiCut"`
  - verified via `sequence-inventory` that V1 had 6 clips and no gaps

Notes:
- Timecode-based ranges remain the recommended path for rough cuts.
