### PR TITLE
Fix QE in/out sync to eliminate rough-cut gaps

### DIFF
--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -233,7 +233,9 @@ function parseTimecodeToFrames(timecode, fps, dropFrameHint) {
     return null;
   }
   const raw = String(timecode);
-  const dropFrame = raw.includes(";") || dropFrameHint === true;
+  // Respect the sequence drop-frame setting; do not infer drop-frame solely
+  // from semicolons when the sequence is explicitly non-drop.
+  const dropFrame = dropFrameHint === true || (dropFrameHint !== false && raw.includes(";"));
   const clean = raw.replace(/;/g, ":");
   const parts = clean.split(":");
   if (parts.length < 4) {


### PR DESCRIPTION
## Summary\n- set QE in/out points using timecode/seconds (avoid raw ticks unit mismatch)\n- add ticks→timecode fallback when QE conversion unavailable\n- avoid treating semicolon timecodes as drop-frame when sequence is non-drop\n\n## Test\n- Ran rough cut on AE - Aligned Tracks with 8 segments → no V1/A1 gaps (Alexander PM Story Rough Cut v6)\n- Verified programmatically: 0 gaps on V1/A1