### PR TITLE
Add explicit set-track-state for video/audio tracks

### DIFF
--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -252,7 +252,8 @@
     "extractRange",
     "rippleDeleteSelection",
     "razorAtTimecode",
-    "toggleVideoTrack"
+    "toggleVideoTrack",
+    "setTrackState"
   ]);
 
   function splitDryRunPayload(payload) {
@@ -361,6 +362,9 @@
     }
     if (command === "toggleVideoTrack") {
       return evalExtendScript("toggleVideoTrack", cleanPayload);
+    }
+    if (command === "setTrackState") {
+      return evalExtendScript("setTrackState", cleanPayload);
     }
     return { ok: false, error: `Unknown command: ${command}` };
   }


### PR DESCRIPTION
## Summary
- add `set-track-state` to the CLI with robust boolean parsing
- implement `setTrackState` in the JSX bridge for both video and audio tracks
- preserve `toggle-video-track` by delegating to the new setter

## Testing
- Reloaded the panel
- `./cli/premiere-bridge.js set-track-state --track V1 --visible true`
- `./cli/premiere-bridge.js set-track-state --track A1 --kind audio --mute true`
- both returned `ok: true` via `qe.setMute`

## Notes
- Panel reload is required so the server recognizes the new command.

Closes #21
