### PR TITLE
Add find-item command for project item lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ codex-premiere-bridge.skill
 dist/
 build/
 coverage/
+WORKPLAN.md

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js duplicate-sequence --name "Rough Cut"
 ./cli/premiere-bridge.js list-sequences
 ./cli/premiere-bridge.js open-sequence --name "Rough Cut"
+./cli/premiere-bridge.js find-item --name "C0114.MP4" --contains --limit 5
 ./cli/premiere-bridge.js sequence-info
 ./cli/premiere-bridge.js sequence-inventory
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
@@ -79,6 +80,7 @@ Color indices:
 - `duplicate-sequence`
 - `list-sequences`
 - `open-sequence`
+- `find-item`
 - `sequence-info`
 - `sequence-inventory`
 - `debug-timecode`

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -16,6 +16,7 @@ Usage:
   premiere-bridge duplicate-sequence [--name NAME] [--port N] [--token TOKEN]
   premiere-bridge list-sequences [--port N] [--token TOKEN]
   premiere-bridge open-sequence (--name NAME | --id ID) [--port N] [--token TOKEN]
+  premiere-bridge find-item (--name NAME | --path BIN/ITEM) [--contains] [--case-sensitive] [--limit N] [--port N] [--token TOKEN]
   premiere-bridge menu-command-id (--name NAME | --names '["Extract","Ripple Delete"]') [--port N] [--token TOKEN]
   premiere-bridge sequence-info [--port N] [--token TOKEN]
   premiere-bridge sequence-inventory [--port N] [--token TOKEN]
@@ -585,6 +586,35 @@ async function main() {
       payload.id = String(args.id);
     }
     const result = await sendCommand(config, "openSequence", attachDryRun(payload, dryRun));
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "find-item") {
+    if (!args.name && !args.path) {
+      throw new Error("Provide --name or --path for find-item");
+    }
+    const payload = {};
+    if (args.name) {
+      payload.name = String(args.name);
+    }
+    if (args.path) {
+      payload.path = String(args.path);
+    }
+    if (flagEnabled(args, "contains")) {
+      payload.contains = true;
+    }
+    if (flagEnabled(args, "case-sensitive")) {
+      payload.caseSensitive = true;
+    }
+    if (args.limit !== undefined) {
+      const limit = Number(args.limit);
+      if (!Number.isFinite(limit) || limit <= 0) {
+        throw new Error("--limit must be a positive number");
+      }
+      payload.limit = Math.round(limit);
+    }
+    const result = await sendCommand(config, "findProjectItem", payload);
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -333,6 +333,9 @@
     if (command === "openSequence") {
       return evalExtendScript("openSequence", cleanPayload);
     }
+    if (command === "findProjectItem") {
+      return evalExtendScript("findProjectItem", cleanPayload);
+    }
     if (command === "findMenuCommandId") {
       return evalExtendScript("findMenuCommandId", cleanPayload);
     }


### PR DESCRIPTION
## What this does
- adds a new `find-item` CLI command
- implements `findProjectItem` in the JSX bridge
- wires the command through the panel server
- returns stable identifiers (`nodeId`) plus bin/full paths and media paths
- ignores local `WORKPLAN.md`

## How to use
```bash
./cli/premiere-bridge.js find-item --name "C0114.MP4" --contains --limit 5
./cli/premiere-bridge.js find-item --path "Footage/Camera 2/Day 2/C0114.MP4"
```

## Why
Track targeting is not scriptable in CEP, so index-driven clip placement needs a reliable way to resolve project items first.

## Testing
- Reloaded the panel
- Verified `ping`
- Verified `find-item` with:
  - `--name "C0114.MP4" --contains`
  - `--name "Video Assist" --contains --limit 3`
  - `--path "Footage/Camera 2/Day 2/C0114.MP4"`

Closes #39
