### PR TITLE
feat(uxp): export transcript JSON via UXP bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ dist/
 build/
 coverage/
 WORKPLAN.md
+
+# Local transcript exports and rough-cut test artifacts
+transcript*.json
+transcript*-compact.txt
+ranges-*-story.json

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The CLI reads the config file above for the port and token.
 ./cli/premiere-bridge.js list-sequences
 ./cli/premiere-bridge.js open-sequence --name "Rough Cut"
 ./cli/premiere-bridge.js find-item --name "C0114.MP4" --contains --limit 5
+./cli/premiere-bridge.js transcript-json --timeout-seconds 45
 ./cli/premiere-bridge.js sequence-info
 ./cli/premiere-bridge.js sequence-inventory
 ./cli/premiere-bridge.js debug-timecode --timecode 00;02;00;00
@@ -81,6 +82,7 @@ Color indices:
 - `list-sequences`
 - `open-sequence`
 - `find-item`
+- `transcript-json` (requires the UXP panel below)
 - `sequence-info`
 - `sequence-inventory`
 - `debug-timecode`
@@ -93,6 +95,41 @@ Color indices:
 - `add-markers`
 - `add-markers-file`
 - `toggle-video-track`
+
+## UXP Transcript Export (Experimental)
+
+Transcript export appears to be available via UXP (not CEP). This repo now includes
+a minimal UXP panel at `premiere-bridge-uxp/` that exports the active sequence
+transcript to JSON.
+
+High-level flow:
+- The UXP panel polls a file-based IPC directory.
+- The CLI writes a `transcriptJSON` command to that directory.
+- The UXP panel writes the result back to disk for the CLI to read.
+
+### Setup (UXP Developer Tools)
+
+1) Open UXP Developer Tools and load `premiere-bridge-uxp/` as a plugin.
+2) In Premiere, open the panel: `Window > Extensions (UXP) > Premiere Bridge UXP`.
+3) Make sure the CEP panel has run at least once to create:
+   `~/Library/Application Support/PremiereBridge/config.json` (for the shared token).
+
+### IPC Location
+
+The UXP panel and CLI communicate via:
+
+- `~/Library/Application Support/PremiereBridge/uxp-ipc/command.json`
+- `~/Library/Application Support/PremiereBridge/uxp-ipc/result.json`
+
+### CLI Usage
+
+```bash
+./cli/premiere-bridge.js transcript-json
+./cli/premiere-bridge.js transcript-json --timeout-seconds 60
+```
+
+If the command times out, ensure the UXP panel is open and the active sequence
+has a transcript available in the Text panel.
 
 ## Rough Cut Command Set
 

--- a/premiere-bridge-uxp/index.html
+++ b/premiere-bridge-uxp/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Premiere Bridge UXP</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="header">
+        <h1 class="title">Premiere Bridge UXP</h1>
+        <p class="subtitle">Transcript export via UXP</p>
+      </header>
+
+      <section class="panel">
+        <div class="row">
+          <div>
+            <div class="label">IPC status</div>
+            <div id="ipc-status" class="value">Starting...</div>
+          </div>
+          <div>
+            <div class="label">Last command</div>
+            <div id="last-command" class="value muted">None</div>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button id="start-btn" class="btn">Start IPC</button>
+          <button id="stop-btn" class="btn ghost">Stop IPC</button>
+          <button id="export-btn" class="btn accent">Export Transcript Now</button>
+        </div>
+
+        <div class="path-block">
+          <div class="label">IPC directory</div>
+          <div id="ipc-dir" class="path">Resolving...</div>
+        </div>
+
+        <div class="log-block">
+          <div class="label">Logs</div>
+          <pre id="log" class="log"></pre>
+        </div>
+      </section>
+    </main>
+
+    <script src="./main.js"></script>
+  </body>
+</html>

--- a/premiere-bridge-uxp/main.js
+++ b/premiere-bridge-uxp/main.js
@@ -1,0 +1,450 @@
+const { entrypoints, storage } = require("uxp");
+let osModule = null;
+let pathModule = null;
+try {
+  osModule = require("os");
+} catch (errOs) {
+}
+try {
+  pathModule = require("path");
+} catch (errPath) {
+}
+const premiere = require("premierepro");
+
+const { localFileSystem, types } = storage;
+
+const PATHS = {
+  baseDir: null,
+  ipcDir: null,
+  commandPath: null,
+  resultPath: null,
+  configPath: null
+};
+
+function joinPath(a, b) {
+  if (pathModule && pathModule.join) {
+    return pathModule.join(a, b);
+  }
+  if (!a) {
+    return b;
+  }
+  return a.endsWith("/") ? a + b : a + "/" + b;
+}
+
+async function ensurePaths() {
+  if (PATHS.baseDir) {
+    return PATHS;
+  }
+  var homePath = null;
+  try {
+    var homeEntry = await localFileSystem.getHomeFolder();
+    if (homeEntry && homeEntry.nativePath) {
+      homePath = homeEntry.nativePath;
+    }
+  } catch (errHome) {
+  }
+  if (!homePath && osModule && osModule.homedir) {
+    try {
+      homePath = osModule.homedir();
+    } catch (errHomedir) {
+    }
+  }
+  if (!homePath) {
+    throw new Error("Unable to resolve home directory");
+  }
+  PATHS.baseDir = joinPath(homePath, "Library/Application Support/PremiereBridge");
+  PATHS.ipcDir = joinPath(PATHS.baseDir, "uxp-ipc");
+  PATHS.commandPath = joinPath(PATHS.ipcDir, "command.json");
+  PATHS.resultPath = joinPath(PATHS.ipcDir, "result.json");
+  PATHS.configPath = joinPath(PATHS.baseDir, "config.json");
+  return PATHS;
+}
+
+const state = {
+  started: false,
+  intervalId: null,
+  lastCommandId: null,
+  pollInFlight: false,
+  initialized: false
+};
+
+let ipcStatusEl;
+let lastCommandEl;
+let ipcDirEl;
+let logEl;
+let startBtn;
+let stopBtn;
+let exportBtn;
+
+function fileUrl(nativePath) {
+  const normalized = nativePath.startsWith("/") ? nativePath : "/" + nativePath;
+  return "file://" + encodeURI(normalized);
+}
+
+function setStatus(text) {
+  if (ipcStatusEl) {
+    ipcStatusEl.textContent = text;
+  }
+}
+
+function setLastCommand(text) {
+  if (lastCommandEl) {
+    lastCommandEl.textContent = text || "None";
+  }
+}
+
+function appendLog(message) {
+  if (!logEl) {
+    return;
+  }
+  const ts = new Date().toISOString();
+  const line = `[${ts}] ${message}`;
+  const prev = logEl.textContent ? logEl.textContent.split("\n") : [];
+  prev.push(line);
+  const trimmed = prev.slice(-120);
+  logEl.textContent = trimmed.join("\n");
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+async function ensureFolder(nativePath) {
+  const url = fileUrl(nativePath);
+  try {
+    return await localFileSystem.getEntryWithUrl(url);
+  } catch (errGet) {
+    try {
+      return await localFileSystem.createEntryWithUrl(url, { type: types.folder });
+    } catch (errCreate) {
+      throw new Error(`Failed to ensure folder at ${nativePath}: ${String(errCreate)}`);
+    }
+  }
+}
+
+async function ensureFile(nativePath) {
+  const url = fileUrl(nativePath);
+  try {
+    return await localFileSystem.getEntryWithUrl(url);
+  } catch (errGet) {
+    try {
+      return await localFileSystem.createEntryWithUrl(url, { type: types.file });
+    } catch (errCreate) {
+      throw new Error(`Failed to ensure file at ${nativePath}: ${String(errCreate)}`);
+    }
+  }
+}
+
+async function readJsonFile(nativePath) {
+  try {
+    const entry = await localFileSystem.getEntryWithUrl(fileUrl(nativePath));
+    const raw = await entry.read();
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw);
+  } catch (err) {
+    return null;
+  }
+}
+
+async function writeJsonFile(nativePath, data) {
+  const entry = await ensureFile(nativePath);
+  await entry.write(JSON.stringify(data, null, 2));
+}
+
+async function readConfig() {
+  const paths = await ensurePaths();
+  const cfg = await readJsonFile(paths.configPath);
+  if (!cfg || !cfg.token) {
+    setStatus("Missing config/token");
+    return null;
+  }
+  return cfg;
+}
+
+async function exportTranscriptJson() {
+  const project = await premiere.Project.getActiveProject();
+  if (!project) {
+    throw new Error("No active project");
+  }
+  const sequence = await project.getActiveSequence();
+  if (!sequence) {
+    throw new Error("No active sequence");
+  }
+  const projectItem = await sequence.getProjectItem();
+  if (!projectItem) {
+    throw new Error("Active sequence has no project item");
+  }
+
+  const clipItem = await premiere.ClipProjectItem.cast(projectItem);
+  if (!clipItem) {
+    throw new Error("Unable to cast sequence project item to ClipProjectItem");
+  }
+
+  const jsonText = await premiere.Transcript.exportToJSON(clipItem);
+  if (!jsonText) {
+    throw new Error("Transcript export returned empty data");
+  }
+
+  let transcriptJson = null;
+  try {
+    transcriptJson = JSON.parse(jsonText);
+  } catch (errParse) {
+    transcriptJson = null;
+  }
+
+  async function readSequenceName(seq) {
+    if (!seq) {
+      return null;
+    }
+    try {
+      if (typeof seq.getName === "function") {
+        const value = await seq.getName();
+        if (value) {
+          return String(value);
+        }
+      }
+    } catch (errGetName) {
+    }
+    try {
+      if (seq.name) {
+        return String(seq.name);
+      }
+    } catch (errNameProp) {
+    }
+    return null;
+  }
+
+  async function readSequenceId(seq) {
+    if (!seq) {
+      return null;
+    }
+    try {
+      if (typeof seq.getSequenceId === "function") {
+        const value = await seq.getSequenceId();
+        if (value !== undefined && value !== null) {
+          return String(value);
+        }
+      }
+    } catch (errGetId) {
+    }
+    const idKeys = ["id", "sequenceID", "sequenceId", "sequence_id"];
+    for (const key of idKeys) {
+      try {
+        if (seq[key] !== undefined && seq[key] !== null) {
+          return String(seq[key]);
+        }
+      } catch (errKey) {
+      }
+    }
+    return null;
+  }
+
+  const seqName = await readSequenceName(sequence);
+  const seqId = await readSequenceId(sequence);
+
+  return {
+    sequence: {
+      name: seqName || null,
+      id: seqId != null ? String(seqId) : null
+    },
+    transcriptText: jsonText,
+    transcriptJson: transcriptJson
+  };
+}
+
+async function handleCommand(command, payload) {
+  if (command === "transcriptJSON") {
+    return await exportTranscriptJson(payload);
+  }
+  throw new Error(`Unknown command: ${command}`);
+}
+
+async function pollOnce() {
+  const paths = await ensurePaths();
+  if (ipcDirEl) {
+    ipcDirEl.textContent = paths.ipcDir;
+  }
+
+  setStatus("Preparing");
+  await ensureFolder(paths.baseDir);
+  await ensureFolder(paths.ipcDir);
+  await ensureFile(paths.commandPath);
+  await ensureFile(paths.resultPath);
+
+  const cfg = await readConfig();
+  if (!cfg) {
+    appendLog(`Config not found at ${paths.configPath}; ensure CEP panel has run at least once.`);
+    return;
+  }
+
+  const command = await readJsonFile(paths.commandPath);
+  if (!command || !command.id || !command.command) {
+    setStatus("Idle");
+    return;
+  }
+
+  if (state.lastCommandId && String(command.id) === String(state.lastCommandId)) {
+    setStatus("Idle");
+    return;
+  }
+
+  state.lastCommandId = String(command.id);
+  setLastCommand(`${command.command} (${command.id})`);
+
+  if (command.token && String(command.token) !== String(cfg.token)) {
+    appendLog("Rejected command due to token mismatch.");
+    await writeJsonFile(paths.resultPath, {
+      id: command.id,
+      ok: false,
+      error: "Token mismatch",
+      timestamp: new Date().toISOString()
+    });
+    setStatus("Idle");
+    return;
+  }
+
+  setStatus("Running");
+  appendLog(`Handling command: ${command.command}`);
+
+  try {
+    const data = await handleCommand(command.command, command.payload || {});
+    await writeJsonFile(paths.resultPath, {
+      id: command.id,
+      ok: true,
+      data,
+      timestamp: new Date().toISOString()
+    });
+    appendLog(`Command completed: ${command.command}`);
+  } catch (err) {
+    await writeJsonFile(paths.resultPath, {
+      id: command.id,
+      ok: false,
+      error: String(err && err.message ? err.message : err),
+      timestamp: new Date().toISOString()
+    });
+    appendLog(`Command failed: ${command.command} -> ${String(err)}`);
+  }
+
+  setStatus("Idle");
+}
+
+async function startIpc() {
+  if (state.started) {
+    return;
+  }
+  state.started = true;
+  setStatus("Starting");
+  appendLog("IPC loop starting.");
+
+  const tick = async () => {
+    if (state.pollInFlight) {
+      return;
+    }
+    state.pollInFlight = true;
+    try {
+      await pollOnce();
+    } catch (err) {
+      appendLog(`IPC error: ${String(err)}`);
+      setStatus("Error");
+    } finally {
+      state.pollInFlight = false;
+    }
+  };
+
+  state.intervalId = setInterval(tick, 700);
+  await tick();
+}
+
+function stopIpc() {
+  if (!state.started) {
+    return;
+  }
+  state.started = false;
+  if (state.intervalId) {
+    clearInterval(state.intervalId);
+    state.intervalId = null;
+  }
+  setStatus("Stopped");
+  appendLog("IPC loop stopped.");
+}
+
+async function manualExport() {
+  appendLog("Manual transcript export requested.");
+  setStatus("Running");
+  try {
+    const data = await exportTranscriptJson();
+    appendLog(
+      `Transcript export OK for sequence: ${data.sequence && data.sequence.name ? data.sequence.name : "(unknown)"}`
+    );
+  } catch (err) {
+    appendLog(`Manual export failed: ${String(err)}`);
+  } finally {
+    setStatus("Idle");
+  }
+}
+
+function wireUi() {
+  ipcStatusEl = document.getElementById("ipc-status");
+  lastCommandEl = document.getElementById("last-command");
+  ipcDirEl = document.getElementById("ipc-dir");
+  logEl = document.getElementById("log");
+  startBtn = document.getElementById("start-btn");
+  stopBtn = document.getElementById("stop-btn");
+  exportBtn = document.getElementById("export-btn");
+
+  if (startBtn) {
+    startBtn.addEventListener("click", () => {
+      startIpc();
+    });
+  }
+  if (stopBtn) {
+    stopBtn.addEventListener("click", () => {
+      stopIpc();
+    });
+  }
+  if (exportBtn) {
+    exportBtn.addEventListener("click", () => {
+      manualExport();
+    });
+  }
+}
+
+function hasUiElements() {
+  return !!(
+    document.getElementById("ipc-status") &&
+    document.getElementById("ipc-dir") &&
+    document.getElementById("log")
+  );
+}
+
+function init() {
+  if (!hasUiElements()) {
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        state.initialized = false;
+        init();
+      },
+      { once: true }
+    );
+    return;
+  }
+  if (!state.initialized) {
+    wireUi();
+    setLastCommand("None");
+    state.initialized = true;
+  }
+  startIpc();
+}
+
+entrypoints.setup({
+  panels: {
+    "premiere-bridge-uxp-panel": {
+      show() {
+        init();
+      },
+      hide() {
+        stopIpc();
+      }
+    }
+  }
+});

--- a/premiere-bridge-uxp/manifest.json
+++ b/premiere-bridge-uxp/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifestVersion": 5,
+  "id": "codex-premiere-bridge-uxp",
+  "name": "Premiere Bridge UXP",
+  "version": "0.1.0",
+  "main": "index.html",
+  "host": {
+    "app": "premierepro",
+    "minVersion": "25.6.0"
+  },
+  "requiredPermissions": {
+    "localFileSystem": "fullAccess"
+  },
+  "entrypoints": [
+    {
+      "type": "panel",
+      "id": "premiere-bridge-uxp-panel",
+      "label": {
+        "default": "Premiere Bridge UXP"
+      }
+    }
+  ]
+}

--- a/premiere-bridge-uxp/style.css
+++ b/premiere-bridge-uxp/style.css
@@ -1,0 +1,142 @@
+:root {
+  --bg: #0b1220;
+  --panel: #0f1a2b;
+  --border: #1f2d45;
+  --text: #e8eefc;
+  --muted: #9fb0d2;
+  --accent: #3aa0ff;
+  --accent-strong: #0b7fe6;
+  --danger: #ff6b6b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 16px;
+  background: radial-gradient(1200px 600px at 0% -20%, #1a2a4a 0%, var(--bg) 55%);
+  color: var(--text);
+  font: 13px/1.45 "SF Pro Text", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.2px;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.panel {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px;
+  background: linear-gradient(180deg, rgba(19, 34, 58, 0.95), rgba(13, 25, 45, 0.95));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--muted);
+  margin-bottom: 2px;
+}
+
+.value {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: #132445;
+  color: var(--text);
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 120ms ease, background-color 120ms ease;
+}
+
+.btn:hover {
+  border-color: #2c4470;
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn.ghost {
+  background: transparent;
+}
+
+.btn.accent {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #051428;
+  font-weight: 700;
+}
+
+.btn.accent:hover {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+  color: white;
+}
+
+.path-block,
+.log-block {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(12, 23, 43, 0.75);
+}
+
+.path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  word-break: break-all;
+}
+
+.log {
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  background: transparent;
+  color: var(--text);
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- add a UXP panel under `premiere-bridge-uxp/` that listens for IPC commands
- implement `transcriptJSON` via `premiere.Transcript.exportToJSON(...)`
- add a `transcript-json` CLI command and document the UXP setup
- ignore local transcript exports/test artifacts in `.gitignore`

## Testing
- `node --check cli/premiere-bridge.js`
- `node --check premiere-bridge-uxp/main.js`
- load the UXP panel in UDT, then run:
  - `./cli/premiere-bridge.js transcript-json --timeout-seconds 120 > transcript.json`
- generate ranges from the transcript and run a dry-run + apply rough cut

Closes #85.
