### PR TITLE
[codex] Add CEP remove-effect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ On macOS, `get-playhead` also verifies the visible Premiere timecode from the UI
 ./cli/premiere-bridge.js set-clip-speed-duration --transport cep --track V1 --timecode "00;00;10;00" --speed-percent 50
 ./cli/premiere-bridge.js add-effect --transport cep --name "Roughen Edges" --selected
 ./cli/premiere-bridge.js set-effect-param --transport cep --effect "Roughen Edges" --param "Border" --value 12 --selected
+./cli/premiere-bridge.js remove-effect --transport cep --name "Roughen Edges" --selected
 ./cli/premiere-bridge.js set-transition --transport cep --state present --track V1 --timecode "00;00;10;00" --name "Cross Dissolve" --duration-frames 15
 ./cli/premiere-bridge.js replace-clip-source --transport cep --track V1 --timecode "00;00;10;00" --item-id 123456
 ./cli/premiere-bridge.js nest-selected-clips --transport cep --name "Nested Host Intro"
@@ -166,6 +167,14 @@ Color indices:
 - Dry-run the command first to verify the matched clip/component/parameter without changing Premiere.
 - The command is CEP-only. It calls the DOM `ComponentParam.setValue(...)` method and verifies the write through component-parameter readback.
 
+`remove-effect` targeting flags:
+- Remove one named non-intrinsic effect component from the selected timeline video clip.
+- Provide the effect with `--name`, for example `--name "Roughen Edges"`.
+- Target the current timeline selection with `--selected`. If exactly one video clip is selected, `--selected` is assumed.
+- Disambiguate duplicate effect components with `--component-index N`, or remove every matching component on the selected clip with `--all-component-matches`.
+- Remove the effect from every selected video clip by adding `--all-matches`; otherwise the bridge errors on multi-clip selections and returns a sample of the selected clips.
+- The command is CEP-only. It refuses fixed/intrinsic components such as Motion and Opacity, attempts host component-removal APIs, then verifies the clip component list decreased and the matching effect count changed as expected.
+
 `set-transition` edit-point flags:
 - Set explicit transition state at a clip edge with `--state present` or `--state absent`.
 - Target one edit point with `--track V1|A1` plus exactly one of `--timecode`, `--frame`, `--seconds`, or `--ticks`.
@@ -211,6 +220,7 @@ Color indices:
 - `set-clip-speed-duration` (CEP only; set clip speed by selection, name, and/or exact track/time selectors)
 - `add-effect` (CEP only; add a named video effect to the selected timeline clip)
 - `set-effect-param` (CEP only; set one parameter on an existing effect component on the selected timeline clip)
+- `remove-effect` (CEP only; remove a named non-intrinsic effect component from the selected timeline clip)
 - `set-transition` (CEP only; set a transition present or absent at one track edit point)
 - `replace-clip-source` (CEP only; replace one targeted timeline clip's source with a project item)
 - `nest-selected-clips` (CEP only; replace the active selected clip range with one nested sequence clip)

--- a/cli/premiere-bridge.js
+++ b/cli/premiere-bridge.js
@@ -29,6 +29,7 @@ Usage:
   premiere-bridge set-clip-speed-duration (--speed N | --speed-percent N | --duration-seconds S | --duration-ticks N) [--ripple true|false] [--reverse true|false] [--preserve-audio-pitch true|false] [--selected] [--match-name NAME] [--all-matches] [--track V1|A1] [--kind video|audio] [--timecode 00;00;10;00 | --frame N | --seconds S | --ticks N] [--transport cep|auto] [--port N] [--token TOKEN]
   premiere-bridge add-effect --name NAME --selected [--all-matches] [--transport cep|auto] [--port N] [--token TOKEN]
   premiere-bridge set-effect-param --effect NAME --param NAME --value VALUE --selected [--value-type auto|number|boolean|string|json] [--component-index N] [--all-matches] [--transport cep|auto] [--port N] [--token TOKEN]
+  premiere-bridge remove-effect --name NAME --selected [--component-index N | --all-component-matches] [--all-matches] [--transport cep|auto] [--port N] [--token TOKEN]
   premiere-bridge set-transition --state present|absent --track V1|A1 (--timecode 00;00;10;00 | --frame N | --seconds S | --ticks N) [--name NAME] [--duration-frames N | --duration-seconds S] [--alignment start|center|end|N] [--single-sided true|false] [--replace true|false] [--transport cep|auto] [--port N] [--token TOKEN]
   premiere-bridge replace-clip-source --item-id ID [--selected | --match-name NAME | --timecode 00;00;10;00 | --frame N | --seconds S | --ticks N] [--track V1|A1] [--kind video|audio] [--transport cep|auto] [--port N] [--token TOKEN]
   premiere-bridge nest-selected-clips [--name NAME] [--video-track-index N] [--ignore-track-targeting true|false] [--transport cep|auto] [--port N] [--token TOKEN]
@@ -77,6 +78,7 @@ Notes:
   set-clip-speed-duration is currently CEP-only and uses the unsupported QE speed API when available, with DOM readback verification.
   add-effect is currently CEP-only and adds a named video effect to the selected timeline clip.
   set-effect-param is currently CEP-only and sets one non-keyframed parameter on one matching effect component on the selected timeline clip.
+  remove-effect is currently CEP-only and removes one named non-intrinsic effect component from the selected timeline clip.
   set-transition is currently CEP-only and targets the edit point on the requested track. Default video transition is Cross Dissolve, default audio transition is Constant Power, and default duration is 15 frames.
   replace-clip-source is currently CEP-only. Prefer --track plus --timecode / --frame for deterministic targeting.
   nest-selected-clips is currently CEP-only and replaces the selected video range with one nested sequence clip. Selected parent audio clips are preserved in place.
@@ -1683,6 +1685,62 @@ function readSetEffectParamPayload(args) {
   return payload;
 }
 
+function readRemoveEffectPayload(args) {
+  const payload = {};
+
+  const name = args.name !== undefined ? args.name : args.effect;
+  if (name === undefined || name === null || String(name).trim() === "") {
+    throw new Error("Provide --name NAME for remove-effect");
+  }
+  payload.name = String(name);
+
+  if (args["component-index"] !== undefined) {
+    const componentIndex = Number(args["component-index"]);
+    if (!Number.isInteger(componentIndex) || componentIndex < 0) {
+      throw new Error("--component-index must be a non-negative integer");
+    }
+    payload.componentIndex = componentIndex;
+  }
+
+  const allComponentMatchesArg = args["all-component-matches"] !== undefined
+    ? args["all-component-matches"]
+    : args["all-components"];
+  if (allComponentMatchesArg !== undefined) {
+    const allComponentMatches = boolOrNull(allComponentMatchesArg);
+    if (allComponentMatches === null) {
+      throw new Error("--all-component-matches must be true or false");
+    }
+    payload.allComponentMatches = allComponentMatches;
+  }
+
+  if (payload.componentIndex !== undefined && payload.allComponentMatches === true) {
+    throw new Error("Use either --component-index or --all-component-matches, not both");
+  }
+
+  if (args.selected !== undefined) {
+    const selected = boolOrNull(args.selected);
+    if (selected === null) {
+      throw new Error("--selected must be true or false");
+    }
+    payload.selected = selected;
+  } else {
+    payload.selected = true;
+  }
+  if (payload.selected !== true) {
+    throw new Error("remove-effect currently requires --selected");
+  }
+
+  if (args["all-matches"] !== undefined) {
+    const allMatches = boolOrNull(args["all-matches"]);
+    if (allMatches === null) {
+      throw new Error("--all-matches must be true or false");
+    }
+    payload.allMatches = allMatches;
+  }
+
+  return payload;
+}
+
 function readReplaceClipSourcePayload(args) {
   const payload = {};
 
@@ -2425,6 +2483,16 @@ async function main() {
     }
     const payload = readSetEffectParamPayload(args);
     const result = await sendCommandCep(config, "setEffectParam", attachDryRun(payload, dryRun));
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (command === "remove-effect") {
+    if ((config.transport || "").toLowerCase() === "uxp") {
+      throw new Error("remove-effect is currently supported only on CEP. Use --transport cep.");
+    }
+    const payload = readRemoveEffectPayload(args);
+    const result = await sendCommandCep(config, "removeEffect", attachDryRun(payload, dryRun));
     console.log(JSON.stringify(result, null, 2));
     return;
   }

--- a/premiere-bridge/js/panel.js
+++ b/premiere-bridge/js/panel.js
@@ -683,6 +683,7 @@
     "setClipSpeedDuration",
     "addEffect",
     "setEffectParam",
+    "removeEffect",
     "setTransition",
     "replaceClipSource",
     "nestSelectedClips",
@@ -1063,6 +1064,12 @@
         return evalExtendScript("setEffectParam", Object.assign({}, cleanPayload, { dryRun: true }));
       }
       return evalExtendScript("setEffectParam", cleanPayload);
+    }
+    if (command === "removeEffect") {
+      if (dryRun) {
+        return evalExtendScript("removeEffect", Object.assign({}, cleanPayload, { dryRun: true }));
+      }
+      return evalExtendScript("removeEffect", cleanPayload);
     }
     if (command === "setTransition") {
       if (dryRun) {

--- a/premiere-bridge/jsx/premiere-bridge.jsx
+++ b/premiere-bridge/jsx/premiere-bridge.jsx
@@ -9074,6 +9074,726 @@ PremiereBridge.setEffectParam = function (jsonStr) {
   }
 };
 
+PremiereBridge.removeEffect = function (jsonStr) {
+  try {
+    var payload = PremiereBridge._parse(jsonStr) || {};
+    var sequence = app.project.activeSequence;
+    if (!sequence) {
+      return PremiereBridge._err("No active sequence");
+    }
+
+    var effectName = payload.name !== undefined && payload.name !== null
+      ? String(payload.name)
+      : (payload.effect !== undefined && payload.effect !== null ? String(payload.effect) : "");
+    if (!effectName.replace(/^\s+|\s+$/g, "")) {
+      return PremiereBridge._err("Provide effect name");
+    }
+
+    var selectedOnly = payload.selected !== false;
+    if (!selectedOnly) {
+      return PremiereBridge._err("removeEffect currently targets selected video clips only");
+    }
+    var allMatches = payload.allMatches === true;
+    var allComponentMatches = payload.allComponentMatches === true;
+    var componentIndex = payload.componentIndex !== undefined && payload.componentIndex !== null
+      ? Number(payload.componentIndex)
+      : null;
+    if (componentIndex !== null && (isNaN(componentIndex) || componentIndex < 0 || Math.round(componentIndex) !== componentIndex)) {
+      return PremiereBridge._err("componentIndex must be a non-negative integer");
+    }
+    if (componentIndex !== null && allComponentMatches) {
+      return PremiereBridge._err("Use either componentIndex or allComponentMatches, not both");
+    }
+    var qeSeq = PremiereBridge._getQeSequence();
+
+    function trackLabel(trackIndex) {
+      return "V" + String(Number(trackIndex) + 1);
+    }
+
+    function timeValueToTicks(value) {
+      var ticks = PremiereBridge._timeToTicks(value);
+      if (ticks !== null && ticks !== undefined && !isNaN(Number(ticks))) {
+        return Math.round(Number(ticks));
+      }
+      return null;
+    }
+
+    function summarizeTicks(ticksValue) {
+      if (ticksValue === null || ticksValue === undefined || isNaN(Number(ticksValue))) {
+        return { ticks: null, seconds: null, timecode: null };
+      }
+      var rounded = Math.round(Number(ticksValue));
+      return {
+        ticks: String(rounded),
+        seconds: rounded / PremiereBridge.TICKS_PER_SECOND,
+        timecode: PremiereBridge._ticksToTimecode(rounded)
+      };
+    }
+
+    function safeName(obj) {
+      if (!obj) {
+        return null;
+      }
+      try {
+        if (obj.displayName !== undefined && obj.displayName !== null) {
+          return String(obj.displayName);
+        }
+      } catch (errDisplayName) {
+      }
+      try {
+        if (obj.name !== undefined && obj.name !== null) {
+          return String(obj.name);
+        }
+      } catch (errName) {
+      }
+      try {
+        if (obj.matchName !== undefined && obj.matchName !== null) {
+          return String(obj.matchName);
+        }
+      } catch (errMatchName) {
+      }
+      return null;
+    }
+
+    function safeMatchName(obj) {
+      try {
+        if (obj && obj.matchName !== undefined && obj.matchName !== null) {
+          return String(obj.matchName);
+        }
+      } catch (errMatchName) {
+      }
+      return null;
+    }
+
+    function itemNodeId(item) {
+      if (!item) {
+        return null;
+      }
+      try {
+        if (item.nodeId !== undefined && item.nodeId !== null) {
+          return String(item.nodeId);
+        }
+      } catch (errNodeId) {
+      }
+      try {
+        if (item.id !== undefined && item.id !== null) {
+          return String(item.id);
+        }
+      } catch (errId) {
+      }
+      return null;
+    }
+
+    function normalizeName(name) {
+      return String(name || "").toLowerCase().replace(/\s+/g, "");
+    }
+
+    function reflectNames(obj, memberName) {
+      var names = [];
+      try {
+        if (obj && obj.reflect && obj.reflect[memberName]) {
+          var members = obj.reflect[memberName];
+          var count = members.length !== undefined ? members.length : 0;
+          for (var i = 0; i < count && i < 80; i++) {
+            try {
+              names.push(String(members[i].name || members[i]));
+            } catch (errMemberName) {
+            }
+          }
+        }
+      } catch (errReflect) {
+      }
+      return names;
+    }
+
+    function summarizeComponent(component, componentIndex) {
+      return {
+        index: componentIndex,
+        name: safeName(component),
+        matchName: safeMatchName(component)
+      };
+    }
+
+    function summarizeComponents(clip) {
+      var components = [];
+      var collection = null;
+      try {
+        collection = clip && clip.components ? clip.components : null;
+      } catch (errComponentCollection) {
+      }
+      var count = PremiereBridge._collectionCount(collection, 128);
+      for (var i = 0; i < count; i++) {
+        var component = null;
+        try {
+          component = collection[i];
+        } catch (errComponent) {
+        }
+        if (!component) {
+          continue;
+        }
+        components.push(summarizeComponent(component, i));
+      }
+      return components;
+    }
+
+    function summarizeClip(clip, trackIndex, clipIndex) {
+      var startTicks = timeValueToTicks(clip && clip.start !== undefined ? clip.start : null);
+      var endTicks = timeValueToTicks(clip && clip.end !== undefined ? clip.end : null);
+      return {
+        kind: "video",
+        trackIndex: trackIndex,
+        track: trackLabel(trackIndex),
+        clipIndex: clipIndex,
+        nodeId: itemNodeId(clip),
+        name: safeName(clip),
+        selected: PremiereBridge._clipSelectionState(clip),
+        start: summarizeTicks(startTicks),
+        end: summarizeTicks(endTicks),
+        components: summarizeComponents(clip)
+      };
+    }
+
+    function collectSelectedVideoClips() {
+      var targets = [];
+      var trackCount = PremiereBridge._collectionCount(sequence.videoTracks, 64);
+      for (var t = 0; t < trackCount; t++) {
+        var track = null;
+        try {
+          track = sequence.videoTracks[t];
+        } catch (errTrack) {
+        }
+        if (!track || !track.clips) {
+          continue;
+        }
+        var clipCount = PremiereBridge._collectionCount(track.clips, 512);
+        for (var c = 0; c < clipCount; c++) {
+          var clip = null;
+          try {
+            clip = track.clips[c];
+          } catch (errClip) {
+          }
+          if (!clip || !PremiereBridge._clipSelectionState(clip)) {
+            continue;
+          }
+          targets.push({
+            clip: clip,
+            trackIndex: t,
+            clipIndex: c,
+            before: summarizeClip(clip, t, c)
+          });
+        }
+      }
+      return targets;
+    }
+
+    function isIntrinsicComponent(summary) {
+      var name = normalizeName(summary && summary.name);
+      var matchName = normalizeName(summary && summary.matchName);
+      return name === "motion" ||
+        name === "opacity" ||
+        name === "timeremapping" ||
+        matchName === normalizeName("AE.ADBE Motion") ||
+        matchName === normalizeName("AE.ADBE Opacity") ||
+        matchName === normalizeName("AE.ADBE Time Remapping");
+    }
+
+    function componentMatchesEffect(summary) {
+      if (!summary) {
+        return false;
+      }
+      return normalizeName(summary.name) === normalizeName(effectName) ||
+        normalizeName(summary.matchName) === normalizeName(effectName);
+    }
+
+    function collectMatchingComponentSummaries(components) {
+      var matches = [];
+      for (var i = 0; i < components.length; i++) {
+        if (componentMatchesEffect(components[i])) {
+          matches.push(components[i]);
+        }
+      }
+      return matches;
+    }
+
+    function findMatchingComponents(clip) {
+      var matches = [];
+      var collection = null;
+      try {
+        collection = clip && clip.components ? clip.components : null;
+      } catch (errComponentCollection) {
+      }
+      var count = PremiereBridge._collectionCount(collection, 128);
+      for (var i = 0; i < count; i++) {
+        var component = null;
+        try {
+          component = collection[i];
+        } catch (errComponent) {
+        }
+        if (!component) {
+          continue;
+        }
+        var summary = summarizeComponent(component, i);
+        var nameMatches = componentMatchesEffect(summary);
+        var indexMatches = componentIndex !== null && i === componentIndex;
+        if ((componentIndex !== null && indexMatches && nameMatches) || (componentIndex === null && nameMatches)) {
+          matches.push({
+            component: component,
+            index: i,
+            summary: summary
+          });
+        }
+      }
+      return matches;
+    }
+
+    function componentCollectionAvailability(clip) {
+      var collection = null;
+      try {
+        collection = clip && clip.components ? clip.components : null;
+      } catch (errCollection) {
+      }
+      return {
+        methodNames: reflectNames(collection, "methods"),
+        propertyNames: reflectNames(collection, "properties")
+      };
+    }
+
+    function getQeItemCount(track) {
+      if (!track) {
+        return null;
+      }
+      try {
+        if (track.numItems !== undefined && track.numItems !== null) {
+          var n = typeof track.numItems === "function" ? Number(track.numItems()) : Number(track.numItems);
+          if (!isNaN(n) && n >= 0) {
+            return Math.round(n);
+          }
+        }
+      } catch (errNumItems) {
+      }
+      return null;
+    }
+
+    function qeItemTimes(item) {
+      return {
+        startTicks: timeValueToTicks(item && item.start !== undefined ? item.start : null),
+        endTicks: timeValueToTicks(item && item.end !== undefined ? item.end : null)
+      };
+    }
+
+    function closeEnoughTicks(actual, expected) {
+      if (actual === null || actual === undefined || expected === null || expected === undefined) {
+        return false;
+      }
+      var a = Number(actual);
+      var e = Number(expected);
+      if (isNaN(a) || isNaN(e)) {
+        return false;
+      }
+      var oneFrameTicks = null;
+      try {
+        oneFrameTicks = PremiereBridge._frameToTicks(1, sequence, qeSeq) - PremiereBridge._frameToTicks(0, sequence, qeSeq);
+      } catch (errFrameTicks) {
+      }
+      if (oneFrameTicks === null || isNaN(Number(oneFrameTicks)) || Number(oneFrameTicks) <= 0) {
+        oneFrameTicks = PremiereBridge.TICKS_PER_SECOND / 60;
+      }
+      return Math.abs(a - e) <= Math.max(2, Math.round(Number(oneFrameTicks) / 2));
+    }
+
+    function findQeTrackItem(target) {
+      var errors = [];
+      if (!qeSeq) {
+        return { item: null, method: null, directExpression: null, errors: ["QE sequence unavailable"] };
+      }
+      if (!qeSeq.getVideoTrackAt) {
+        return { item: null, method: null, directExpression: null, errors: ["QE getVideoTrackAt unavailable"] };
+      }
+      var qeTrack = null;
+      try {
+        qeTrack = qeSeq.getVideoTrackAt(target.trackIndex);
+      } catch (errQeTrack) {
+        return { item: null, method: null, directExpression: null, errors: ["QE track lookup failed: " + String(errQeTrack)] };
+      }
+      if (!qeTrack || !qeTrack.getItemAt) {
+        return { item: null, method: null, directExpression: null, errors: ["QE track item lookup unavailable"] };
+      }
+
+      var wantedStart = target.before.start && target.before.start.ticks !== null ? Number(target.before.start.ticks) : null;
+      var wantedEnd = target.before.end && target.before.end.ticks !== null ? Number(target.before.end.ticks) : null;
+      var count = getQeItemCount(qeTrack);
+      var limit = count !== null ? Math.min(count, 512) : 512;
+      var misses = 0;
+      for (var i = 0; i < limit; i++) {
+        var item = null;
+        var itemExpression = "qe.project.getActiveSequence().getVideoTrackAt(" + target.trackIndex + ").getItemAt(" + i + ")";
+        try {
+          item = qeTrack.getItemAt(i);
+        } catch (errQeItem) {
+          try {
+            item = eval(itemExpression);
+          } catch (errQeItemDirect) {
+            errors.push("qeTrack.getItemAt(" + i + "): " + String(errQeItem) + "; " + itemExpression + ": " + String(errQeItemDirect));
+            if (count === null) {
+              break;
+            }
+          }
+        }
+        if (!item) {
+          misses++;
+          if (count === null && misses > 12) {
+            break;
+          }
+          continue;
+        }
+        misses = 0;
+        var times = qeItemTimes(item);
+        if (closeEnoughTicks(times.startTicks, wantedStart) && closeEnoughTicks(times.endTicks, wantedEnd)) {
+          return {
+            item: item,
+            method: "qe.getVideoTrackAt(" + target.trackIndex + ").getItemAt(" + i + ")",
+            directExpression: itemExpression,
+            errors: errors
+          };
+        }
+      }
+      return {
+        item: null,
+        method: null,
+        directExpression: null,
+        errors: errors.length ? errors : ["No matching QE video track item found"]
+      };
+    }
+
+    function qeTargetAvailability(target) {
+      var qeMatch = findQeTrackItem(target);
+      return {
+        found: !!qeMatch.item,
+        method: qeMatch.method,
+        errors: qeMatch.errors,
+        itemMethodNames: reflectNames(qeMatch.item, "methods"),
+        itemPropertyNames: reflectNames(qeMatch.item, "properties")
+      };
+    }
+
+    function qeComponentCount(qeItem) {
+      if (!qeItem) {
+        return 0;
+      }
+      try {
+        if (qeItem.numComponents !== undefined && qeItem.numComponents !== null) {
+          var n = typeof qeItem.numComponents === "function" ? Number(qeItem.numComponents()) : Number(qeItem.numComponents);
+          if (!isNaN(n) && n >= 0) {
+            return Math.min(128, Math.round(n));
+          }
+        }
+      } catch (errNumComponents) {
+      }
+      return 0;
+    }
+
+    function summarizeQeComponent(qeComponent, index) {
+      return {
+        index: index,
+        name: safeName(qeComponent),
+        matchName: safeMatchName(qeComponent),
+        methodNames: reflectNames(qeComponent, "methods"),
+        propertyNames: reflectNames(qeComponent, "properties")
+      };
+    }
+
+    function summarizeQeComponents(target) {
+      var qeMatch = findQeTrackItem(target);
+      var summaries = [];
+      var errors = qeMatch.errors ? qeMatch.errors.slice(0) : [];
+      if (!qeMatch.item) {
+        return {
+          found: false,
+          method: qeMatch.method,
+          errors: errors,
+          components: summaries
+        };
+      }
+      if (!qeMatch.item.getComponentAt) {
+        errors.push("qeItem.getComponentAt unavailable");
+        return {
+          found: true,
+          method: qeMatch.method,
+          errors: errors,
+          components: summaries
+        };
+      }
+      var count = qeComponentCount(qeMatch.item);
+      for (var i = 0; i < count; i++) {
+        try {
+          var qeComponent = qeMatch.item.getComponentAt(i);
+          summaries.push(summarizeQeComponent(qeComponent, i));
+        } catch (errQeComponent) {
+          errors.push("qeItem.getComponentAt(" + i + "): " + String(errQeComponent));
+        }
+      }
+      return {
+        found: true,
+        method: qeMatch.method,
+        errors: errors,
+        componentCount: count,
+        components: summaries
+      };
+    }
+
+    function removeComponent(target, match) {
+      var errors = [];
+      if (match.component && match.component.remove) {
+        try {
+          match.component.remove();
+          return { ok: true, method: "component.remove()" };
+        } catch (errComponentRemove) {
+          errors.push("component.remove(): " + String(errComponentRemove));
+        }
+      } else {
+        errors.push("component.remove unavailable");
+      }
+
+      var collection = null;
+      try {
+        collection = target.clip && target.clip.components ? target.clip.components : null;
+      } catch (errCollection) {
+      }
+      if (collection && collection.remove) {
+        try {
+          collection.remove(match.component);
+          return { ok: true, method: "clip.components.remove(component)" };
+        } catch (errCollectionRemoveObject) {
+          errors.push("clip.components.remove(component): " + String(errCollectionRemoveObject));
+        }
+        try {
+          collection.remove(match.index);
+          return { ok: true, method: "clip.components.remove(index)" };
+        } catch (errCollectionRemoveIndex) {
+          errors.push("clip.components.remove(index): " + String(errCollectionRemoveIndex));
+        }
+      } else {
+        errors.push("clip.components.remove unavailable");
+      }
+      if (collection && collection.removeAt) {
+        try {
+          collection.removeAt(match.index);
+          return { ok: true, method: "clip.components.removeAt(index)" };
+        } catch (errCollectionRemoveAt) {
+          errors.push("clip.components.removeAt(index): " + String(errCollectionRemoveAt));
+        }
+      } else {
+        errors.push("clip.components.removeAt unavailable");
+      }
+
+      var qeMatch = findQeTrackItem(target);
+      if (qeMatch.item && qeMatch.item.getComponentAt) {
+        try {
+          var qeComponent = qeMatch.item.getComponentAt(match.index);
+          var qeSummary = summarizeQeComponent(qeComponent, match.index);
+          if (!componentMatchesEffect(qeSummary)) {
+            errors.push("qeItem.getComponentAt(" + match.index + ") returned different component: " + qeSummary.name + " / " + qeSummary.matchName);
+          } else if (!qeComponent || !qeComponent.remove) {
+            errors.push("qeComponent.remove unavailable");
+          } else {
+            qeComponent.remove();
+            return {
+              ok: true,
+              method: (qeMatch.method || "qeTrackItem") + ".getComponentAt(" + match.index + ").remove()"
+            };
+          }
+        } catch (errQeRemove) {
+          errors.push("qeComponent.remove(): " + String(errQeRemove));
+        }
+      } else {
+        errors.push("QE component remove unavailable: " + ((qeMatch.errors && qeMatch.errors.join("; ")) || "no matching QE item"));
+      }
+
+      return {
+        ok: false,
+        method: null,
+        error: errors.join("; "),
+        availability: {
+          component: {
+            methodNames: reflectNames(match.component, "methods"),
+            propertyNames: reflectNames(match.component, "properties")
+          },
+          qeTarget: qeTargetAvailability(target),
+          qeComponents: summarizeQeComponents(target),
+          componentCollection: componentCollectionAvailability(target.clip)
+        }
+      };
+    }
+
+    function criteriaSummary() {
+      return {
+        name: effectName,
+        selected: selectedOnly,
+        allMatches: allMatches,
+        allComponentMatches: allComponentMatches,
+        componentIndex: componentIndex
+      };
+    }
+
+    var targets = collectSelectedVideoClips();
+    if (!targets.length) {
+      return PremiereBridge._err("No selected video clip found");
+    }
+    if (targets.length > 1 && !allMatches) {
+      var selectedSample = [];
+      for (var s = 0; s < Math.min(5, targets.length); s++) {
+        selectedSample.push(targets[s].before);
+      }
+      return PremiereBridge._err("Multiple selected video clips found. Add --all-matches or select one clip.", {
+        selectedCount: targets.length,
+        selectedSample: selectedSample
+      });
+    }
+    var selectedTargets = allMatches ? targets : [targets[0]];
+
+    var prepared = [];
+    for (var prep = 0; prep < selectedTargets.length; prep++) {
+      var target = selectedTargets[prep];
+      var matches = findMatchingComponents(target.clip);
+      if (!matches.length) {
+        return PremiereBridge._err("Effect component not found: " + effectName, {
+          criteria: criteriaSummary(),
+          target: target.before,
+          availableComponents: summarizeComponents(target.clip)
+        });
+      }
+      var blocked = [];
+      for (var b = 0; b < matches.length; b++) {
+        if (isIntrinsicComponent(matches[b].summary)) {
+          blocked.push(matches[b].summary);
+        }
+      }
+      if (blocked.length) {
+        return PremiereBridge._err("Refusing to remove intrinsic clip component: " + effectName, {
+          criteria: criteriaSummary(),
+          target: target.before,
+          blockedComponents: blocked
+        });
+      }
+      if (matches.length > 1 && componentIndex === null && !allComponentMatches) {
+        var matchSample = [];
+        for (var m = 0; m < matches.length; m++) {
+          matchSample.push(matches[m].summary);
+        }
+        return PremiereBridge._err("Multiple matching effect components found. Provide --component-index or --all-component-matches.", {
+          criteria: criteriaSummary(),
+          target: target.before,
+          matchingComponents: matchSample
+        });
+      }
+      prepared.push({
+        target: target,
+        matches: allComponentMatches ? matches : [matches[0]]
+      });
+    }
+
+    if (payload.dryRun === true) {
+      var dryMatches = [];
+      for (var d = 0; d < prepared.length; d++) {
+        var dryComponentMatches = [];
+        for (var dc = 0; dc < prepared[d].matches.length; dc++) {
+          dryComponentMatches.push(prepared[d].matches[dc].summary);
+        }
+        dryMatches.push({
+          target: prepared[d].target.before,
+          componentsToRemove: dryComponentMatches
+        });
+      }
+      return PremiereBridge._ok({
+        dryRun: true,
+        skipped: true,
+        criteria: criteriaSummary(),
+        selectedCount: targets.length,
+        targetCount: prepared.length,
+        matches: dryMatches
+      });
+    }
+
+    var changed = [];
+    var errors = [];
+    for (var i = 0; i < prepared.length; i++) {
+      var item = prepared[i];
+      var removeMatches = item.matches.slice(0);
+      removeMatches.sort(function (a, b) {
+        return b.index - a.index;
+      });
+      var before = summarizeClip(item.target.clip, item.target.trackIndex, item.target.clipIndex);
+      var beforeMatchingCount = collectMatchingComponentSummaries(before.components).length;
+      var removed = [];
+      var removeErrors = [];
+      for (var r = 0; r < removeMatches.length; r++) {
+        var removeResult = removeComponent(item.target, removeMatches[r]);
+        if (removeResult.ok) {
+          removed.push({
+            method: removeResult.method,
+            before: removeMatches[r].summary
+          });
+        } else {
+          removeErrors.push({
+            before: removeMatches[r].summary,
+            error: removeResult.error,
+            availability: removeResult.availability
+          });
+        }
+      }
+      var after = summarizeClip(item.target.clip, item.target.trackIndex, item.target.clipIndex);
+      var afterMatchingComponents = collectMatchingComponentSummaries(after.components);
+      var expectedRemoved = removed.length;
+      var componentCountDecreased = after.components.length === before.components.length - expectedRemoved;
+      var matchingCountDecreased = afterMatchingComponents.length === beforeMatchingCount - expectedRemoved;
+      var verified = removeErrors.length === 0 && expectedRemoved > 0 && componentCountDecreased && matchingCountDecreased;
+      var resultEntry = {
+        target: {
+          before: before,
+          after: after
+        },
+        removed: removed,
+        requested: {
+          name: effectName,
+          removedComponentCount: expectedRemoved
+        },
+        verification: {
+          componentCountDecreased: componentCountDecreased,
+          matchingCountBefore: beforeMatchingCount,
+          matchingCountAfter: afterMatchingComponents.length,
+          matchingCountDecreased: matchingCountDecreased,
+          remainingMatchingComponents: afterMatchingComponents
+        }
+      };
+      if (verified) {
+        changed.push(resultEntry);
+      } else {
+        resultEntry.error = removeErrors.length ? "One or more component-removal attempts failed" : "Effect removal did not verify in clip components";
+        resultEntry.errors = removeErrors;
+        errors.push(resultEntry);
+      }
+    }
+
+    if (errors.length) {
+      return PremiereBridge._err("Failed to remove one or more video effects", {
+        criteria: criteriaSummary(),
+        changedCount: changed.length,
+        errorCount: errors.length,
+        changed: changed,
+        errors: errors
+      });
+    }
+
+    return PremiereBridge._ok({
+      criteria: criteriaSummary(),
+      changedCount: changed.length,
+      changed: changed
+    });
+  } catch (err) {
+    return PremiereBridge._err(String(err));
+  }
+};
+
 PremiereBridge.setTransition = function (jsonStr) {
   try {
     var payload = PremiereBridge._parse(jsonStr) || {};


### PR DESCRIPTION
## What
- Add a CEP-backed `remove-effect` CLI command for removing named non-intrinsic effects from the selected timeline clip.
- Wire the command through the CEP panel to ExtendScript with dry-run support, target/component summaries, removal verification, and a QE fallback for hosts that do not expose DOM removal.
- Document usage and options in the README.

## Why
Issue 31 asks for reliable clip effect removal from the bridge. This keeps built-in effect application, parameter setting, and removal available through the same CEP command path.

Closes #31

## Validation
- `node --check cli/premiere-bridge.js`
- `node --check premiere-bridge-uxp/main.js`
- `node --check premiere-bridge/js/panel.js`
- `node --check /tmp/premiere-bridge-check.js`
- `node cli/premiere-bridge.js help`
- `git diff --check`
- `./cli/premiere-bridge.js reload-panel --transport cep`
- `./cli/premiere-bridge.js ping --transport cep`
- Added a temporary Gaussian Blur effect, dry-ran removal, then removed it from the selected clip in Premiere
- Dry-ran Roughen Edges removal and then confirmed it was already gone from the selected clip